### PR TITLE
Update container used in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg /bin/bash
-    - name: Setup container
-      run: |
-        docker exec CI_container /bin/bash -c " ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so;"
+        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: CMake Configure
       run: |
         docker exec CI_container /bin/bash -c 'cd Package;\


### PR DESCRIPTION
Dockerhub hosted one has been removed due to potential clash with new docker TOS

Image from https://github.com/AIDASoft/management/pkgs/container/centos7