### PR TITLE
Rename GeoSvc to ActsGeoSvc

### DIFF
--- a/geosvc.py
+++ b/geosvc.py
@@ -21,11 +21,11 @@ import sys
 from pprint import pprint
 from Gaudi.Configuration import *
 
-from Configurables import GeoSvc
+from Configurables import ActsGeoSvc
 
 algList = []
 
-a = GeoSvc("GeoSvc")
+a = ActsGeoSvc("ActsGeoSvc")
 a.detectors = ["/home/delitez/ACTS/acts/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml"]
 a.debugGeometry = True
 a.outputFileName = "MyObjFile"

--- a/k4ActsTracking/src/components/ActsGeoSvc.cpp
+++ b/k4ActsTracking/src/components/ActsGeoSvc.cpp
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-#include "GeoSvc.h"
+#include "ActsGeoSvc.h"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp"
@@ -32,11 +32,11 @@
 
 using namespace Gaudi;
 
-DECLARE_COMPONENT(GeoSvc)
+DECLARE_COMPONENT(ActsGeoSvc)
 
-GeoSvc::GeoSvc(const std::string& name, ISvcLocator* svc) : base_class(name, svc), m_log(msgSvc(), name) {}
+ActsGeoSvc::ActsGeoSvc(const std::string& name, ISvcLocator* svc) : base_class(name, svc), m_log(msgSvc(), name) {}
 
-GeoSvc::~GeoSvc() {
+ActsGeoSvc::~ActsGeoSvc() {
   if (m_dd4hepGeo != nullptr) {
     try {
       m_dd4hepGeo->destroyInstance();
@@ -46,7 +46,7 @@ GeoSvc::~GeoSvc() {
   }
 }
 
-StatusCode GeoSvc::initialize() {
+StatusCode ActsGeoSvc::initialize() {
   if (m_xmlFileNames.size() > 0) {
     m_log << MSG::INFO << "Loading xml files from:  '" << m_xmlFileNames << "'" << endmsg;
   } else {
@@ -92,13 +92,13 @@ StatusCode GeoSvc::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode GeoSvc::execute() { return StatusCode::SUCCESS; }
+StatusCode ActsGeoSvc::execute() { return StatusCode::SUCCESS; }
 
-StatusCode GeoSvc::finalize() { return StatusCode::SUCCESS; }
+StatusCode ActsGeoSvc::finalize() { return StatusCode::SUCCESS; }
 
-StatusCode GeoSvc::buildDD4HepGeo() {
+StatusCode ActsGeoSvc::buildDD4HepGeo() {
   m_dd4hepGeo = &(dd4hep::Detector::getInstance());
-  m_dd4hepGeo->addExtension<IGeoSvc>(this);
+  m_dd4hepGeo->addExtension<IActsGeoSvc>(this);
 
   /// Load geometry
   for (auto& filename : m_xmlFileNames) {
@@ -112,7 +112,7 @@ StatusCode GeoSvc::buildDD4HepGeo() {
 }
 
 /// Create a geometry OBJ file
-StatusCode GeoSvc::createGeoObj() {
+StatusCode ActsGeoSvc::createGeoObj() {
   // Convert DD4Hep geometry to acts
 
   Acts::ObjVisualization3D m_obj;

--- a/k4ActsTracking/src/components/ActsGeoSvc.h
+++ b/k4ActsTracking/src/components/ActsGeoSvc.h
@@ -35,9 +35,9 @@
 #include "GaudiKernel/MsgStream.h"
 #include "GaudiKernel/Service.h"
 #include "GaudiKernel/ServiceHandle.h"
-#include "IGeoSvc.h"
+#include "IActsGeoSvc.h"
 
-class GeoSvc : public extends<Service, IGeoSvc> {
+class ActsGeoSvc : public extends<Service, IActsGeoSvc> {
 public:
   using VolumeSurfaceMap = std::unordered_map<uint64_t, const Acts::Surface*>;
 
@@ -74,9 +74,9 @@ private:
   MsgStream m_log;
 
 public:
-  GeoSvc(const std::string& name, ISvcLocator* svc);
+  ActsGeoSvc(const std::string& name, ISvcLocator* svc);
 
-  virtual ~GeoSvc();
+  virtual ~ActsGeoSvc();
 
   virtual StatusCode initialize() final;
 
@@ -91,5 +91,5 @@ public:
   virtual const Acts::TrackingGeometry& trackingGeometry() const;
 };
 
-inline const Acts::TrackingGeometry& GeoSvc::trackingGeometry() const { return *m_trackingGeo; }
+inline const Acts::TrackingGeometry& ActsGeoSvc::trackingGeometry() const { return *m_trackingGeo; }
 #endif

--- a/k4ActsTracking/src/components/IActsGeoSvc.h
+++ b/k4ActsTracking/src/components/IActsGeoSvc.h
@@ -34,16 +34,16 @@ namespace Acts {
   class Surface;
 }  // namespace Acts
 
-class GAUDI_API IGeoSvc : virtual public IService {
+class GAUDI_API IActsGeoSvc : virtual public IService {
 public:
   using VolumeSurfaceMap = std::unordered_map<uint64_t, const Acts::Surface*>;
 
 public:
-  DeclareInterfaceID(IGeoSvc, 1, 0);
+  DeclareInterfaceID(IActsGeoSvc, 1, 0);
 
   virtual const Acts::TrackingGeometry& trackingGeometry() const = 0;
 
-  virtual ~IGeoSvc() {}
+  virtual ~IActsGeoSvc() {}
 };
 
 #endif  // IGEOSVC_H


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename GeoSvc to ActsGeoSvc to avoid clash with `k4FWcore/GeoSvc`

ENDRELEASENOTES

Contains parts of https://github.com/key4hep/k4ActsTracking/pull/10