### PR TITLE
Update GeoSvc to new convertDD4hepDetector interface

### DIFF
--- a/k4ActsTracking/src/components/GeoSvc.cpp
+++ b/k4ActsTracking/src/components/GeoSvc.cpp
@@ -26,6 +26,7 @@
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Visualization/GeometryView3D.hpp"
 #include "Acts/Visualization/ObjVisualization3D.hpp"
+#include "Acts/Utilities/Logger.hpp"
 #include "DD4hep/Printout.h"
 #include "GaudiKernel/Service.h"
 #include "TGeoManager.h"
@@ -69,7 +70,8 @@ StatusCode GeoSvc::initialize() {
   double            layerEnvelopeZ        = Acts::UnitConstants::mm;
   double            defaultLayerThickness = Acts::UnitConstants::fm;
   using Acts::sortDetElementsByID;
-  m_trackingGeo = Acts::convertDD4hepDetector(m_dd4hepGeo->world(), m_actsLoggingLevel, bTypePhi, bTypeR, bTypeZ,
+  auto logger = Acts::getDefaultLogger("k4ActsTracking", m_actsLoggingLevel);
+  m_trackingGeo = Acts::convertDD4hepDetector(m_dd4hepGeo->world(), *logger, bTypePhi, bTypeR, bTypeZ,
                                               layerEnvelopeR, layerEnvelopeZ, defaultLayerThickness,
                                               sortDetElementsByID, m_trackingGeoCtx, m_materialDeco);
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Update GeoSvc to new (ACTS v24+) convertDD4hepDetector interface

ENDRELEASENOTES

needed once we bump the spack commit in key4hep-spack and do a new from scratch build.

I basically copied the changes from https://github.com/acts-project/acts/pull/1911