### PR TITLE
Use GeoSvc to get dd4hep geometry instead of loading it ourselves

### DIFF
--- a/k4ActsTracking/src/components/ActsGeoSvc.h
+++ b/k4ActsTracking/src/components/ActsGeoSvc.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef GEOSVC_H
-#define GEOSVC_H
+#ifndef ACTSGEOSVC_H
+#define ACTSGEOSVC_H
 
 #include <Acts/Material/IMaterialDecorator.hpp>
 #include "Acts/Definitions/Common.hpp"
@@ -62,8 +62,7 @@ private:
   /// ACTS surface lookup container for hit surfaces that generate smeared hits
   VolumeSurfaceMap m_surfaces;
 
-  /// XML-files with the detector description
-  Gaudi::Property<std::vector<std::string>> m_xmlFileNames{this, "detectors", {}, "Detector descriptions XML-files"};
+  Gaudi::Property<std::string> m_geoSvcName{this, "GeoSvcName", "GeoSvc", "The name of the GeoSvc instance"};
 
   /// Option for the Debug Geometry
   Gaudi::Property<bool> m_debugGeometry{this, "debugGeometry", false, "Option for geometry debugging"};
@@ -83,8 +82,6 @@ public:
   virtual StatusCode execute() final;
 
   virtual StatusCode finalize() final;
-
-  StatusCode buildDD4HepGeo();
 
   StatusCode createGeoObj();
 

--- a/k4ActsTracking/src/components/IActsGeoSvc.h
+++ b/k4ActsTracking/src/components/IActsGeoSvc.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef IGEOSVC_H
-#define IGEOSVC_H
+#ifndef IACTSGEOSVC_H
+#define IACTSGEOSVC_H
 
 #include <GaudiKernel/IService.h>
 #include <unordered_map>
@@ -46,4 +46,4 @@ public:
   virtual ~IActsGeoSvc() {}
 };
 
-#endif  // IGEOSVC_H
+#endif  // IACTSGEOSVC_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,3 +35,9 @@ add_test(NAME LoadODD
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND k4run options/geosvc.py)
 set_test_env(LoadODD)
+
+add_test(NAME CheckODDObjFile
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+         COMMAND test -s MyObjFile.mtl)
+set_test_env(CheckODDObjFile)
+set_tests_properties(CheckODDObjFile PROPERTIES DEPENDS LoadODD)

--- a/test/options/geosvc.py
+++ b/test/options/geosvc.py
@@ -17,19 +17,26 @@
 # limitations under the License.
 #
 import os
-from pprint import pprint
-from Gaudi.Configuration import *
+from Gaudi.Configuration import INFO
 
-from Configurables import ActsGeoSvc
+from Configurables import ActsGeoSvc, ApplicationMgr, GeoSvc
 
 algList = []
 
-a = ActsGeoSvc("ActsGeoSvc")
-a.detectors = [f"{os.environ['OPENDATADETECTOR']}/xml/OpenDataDetector.xml"]
-a.debugGeometry = True
-a.outputFileName = "MyObjFile"
-from Configurables import ApplicationMgr
+dd4hep_geo = GeoSvc("GeoSvc")
+dd4hep_geo.detectors = [f"{os.environ['OPENDATADETECTOR']}/xml/OpenDataDetector.xml"]
+dd4hep_geo.EnableGeant4Geo = False
 
-ApplicationMgr(TopAlg=algList, EvtSel="NONE", EvtMax=2, ExtSvc=[
-a
-], OutputLevel=INFO)
+acts_geo = ActsGeoSvc("ActsGeoSvc")
+acts_geo.GeoSvcName = dd4hep_geo.name()
+acts_geo.debugGeometry = True
+acts_geo.outputFileName = "MyObjFile"
+
+ApplicationMgr(
+    TopAlg=algList,
+    EvtSel="NONE",
+    EvtMax=2,
+    # order dependent...
+    ExtSvc=[dd4hep_geo, acts_geo],
+    OutputLevel=INFO,
+)


### PR DESCRIPTION
BEGINRELEASENOTES
- Use GeoSvc to get dd4hep geometry instead of loading it ourselves
- Test if exported geometry contains anything

ENDRELEASENOTES

resolves #16 