### PR TITLE
fix: explicitly use Gaudi::Property<std::string>::value() in ActsGeoSvc.cpp

### DIFF
--- a/k4ActsTracking/src/components/ActsGeoSvc.cpp
+++ b/k4ActsTracking/src/components/ActsGeoSvc.cpp
@@ -94,7 +94,7 @@ StatusCode ActsGeoSvc::createGeoObj() {
     }
     Acts::GeometryView3D::drawSurface(m_obj, *surface, m_trackingGeoCtx);
   });
-  m_obj.write(m_outputFileName);
+  m_obj.write(m_outputFileName.value());
   m_log << MSG::INFO << m_outputFileName << " SUCCESSFULLY written." << endmsg;
 
   return StatusCode::SUCCESS;


### PR DESCRIPTION
With gaudi-38.3 and acts-37.0.0, I am encountering the following compilation error:
```
/opt/spack/stage/wdconinc/spack-stage-k4actstracking-git.2f6958b4998d17a32b5b93b59d048a9f0435df3e_main-3xb75mlrecyn7pcx44v5khn7stmgazex/spack-src/k4ActsTracking/src/components/ActsGeoSvc.cpp: In member function 'StatusCode ActsGeoSvc::createGeoObj()':
/opt/spack/stage/wdconinc/spack-stage-k4actstracking-git.2f6958b4998d17a32b5b93b59d048a9f0435df3e_main-3xb75mlrecyn7pcx44v5khn7stmgazex/spack-src/k4ActsTracking/src/components/ActsGeoSvc.cpp:102:16: error: no matching function for call to 'Acts::ObjVisualization3D<double>::write(Gaudi::Property<std::__cxx11::basic_string<char> >&)'
  102 |     m_obj.write(m_outputFileName);
      |     ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
In file included from /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/acts-37.0.0-bugai4cn4dwm6aufq22nuvxm4xiohdio/include/Acts/Visualization/ObjVisualization3D.hpp:95,
                 from /opt/spack/stage/wdconinc/spack-stage-k4actstracking-git.2f6958b4998d17a32b5b93b59d048a9f0435df3e_main-3xb75mlrecyn7pcx44v5khn7stmgazex/spack-src/k4ActsTracking/src/components/ActsGeoSvc.cpp:28:
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/acts-37.0.0-bugai4cn4dwm6aufq22nuvxm4xiohdio/include/Acts/Visualization/detail/ObjVisualization3D.ipp:93:6: note: candidate: 'void Acts::ObjVisualization3D<T>::write(std::ostream&) const [with T = double; std::ostream = std::basic_ostream<char>]'
   93 | void ObjVisualization3D<T>::write(std::ostream& os) const {
      |      ^~~~~~~~~~~~~~~~~~~~~
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/acts-37.0.0-bugai4cn4dwm6aufq22nuvxm4xiohdio/include/Acts/Visualization/detail/ObjVisualization3D.ipp:93:49: note:   no known conversion for argument 1 from 'Gaudi::Property<std::__cxx11::basic_string<char> >' to 'std::ostream&' {aka 'std::basic_ostream<char>&'}
   93 | void ObjVisualization3D<T>::write(std::ostream& os) const {
      |                                   ~~~~~~~~~~~~~~^~
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/acts-37.0.0-bugai4cn4dwm6aufq22nuvxm4xiohdio/include/Acts/Visualization/detail/ObjVisualization3D.ipp:72:6: note: candidate: 'void Acts::ObjVisualization3D<T>::write(const std::filesystem::__cxx11::path&) const [with T = double]'
   72 | void ObjVisualization3D<T>::write(const std::filesystem::path& path) const {
      |      ^~~~~~~~~~~~~~~~~~~~~
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/acts-37.0.0-bugai4cn4dwm6aufq22nuvxm4xiohdio/include/Acts/Visualization/detail/ObjVisualization3D.ipp:72:64: note:   no known conversion for argument 1 from 'Gaudi::Property<std::__cxx11::basic_string<char> >' to 'const std::filesystem::__cxx11::path&'
   72 | void ObjVisualization3D<T>::write(const std::filesystem::path& path) const {
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/acts-37.0.0-bugai4cn4dwm6aufq22nuvxm4xiohdio/include/Acts/Visualization/detail/ObjVisualization3D.ipp:99:6: note: candidate: 'void Acts::ObjVisualization3D<T>::write(std::ostream&, std::ostream&) const [with T = double; std::ostream = std::basic_ostream<char>]'
   99 | void ObjVisualization3D<T>::write(std::ostream& os, std::ostream& mos) const {
      |      ^~~~~~~~~~~~~~~~~~~~~
```

This appears to be caused by the change to the syntax of write in https://github.com/acts-project/acts/commit/74d9aa24653027858659e28f3e6f0275cf799d6c (first in v37.0.0).

This PR explicitly gets the value of the `Gaudi::Property<std::string>` to ensure the conversion happens correctly. 

BEGINRELEASENOTES
- explicitly use Gaudi::Property<std::string>::value() in ActsGeoSvc.cpp

ENDRELEASENOTES
