### PR TITLE
feat: rm GaudiAlg dependence

### DIFF
--- a/k4ActsTracking/CMakeLists.txt
+++ b/k4ActsTracking/CMakeLists.txt
@@ -20,7 +20,7 @@ file(GLOB _plugin_sources src/components/*.cpp)
 gaudi_add_module(k4ActsTrackingPlugins
   SOURCES ${_plugin_sources}
   LINK
-  Gaudi::GaudiKernel Gaudi::GaudiAlgLib
+  Gaudi::GaudiKernel
   k4FWCore::k4FWCore
   EDM4HEP::edm4hep
   DD4hep::DDCore DD4hep::DDRec

--- a/k4ActsTracking/src/components/EmptyAlg.cpp
+++ b/k4ActsTracking/src/components/EmptyAlg.cpp
@@ -20,13 +20,13 @@
 
 DECLARE_COMPONENT(EmptyAlg)
 
-EmptyAlg::EmptyAlg(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc) {}
+EmptyAlg::EmptyAlg(const std::string& aName, ISvcLocator* aSvcLoc) : Gaudi::Algorithm(aName, aSvcLoc) {}
 
 EmptyAlg::~EmptyAlg() {}
 
 StatusCode EmptyAlg::initialize() { return StatusCode::SUCCESS; }
 
-StatusCode EmptyAlg::execute() {
+StatusCode EmptyAlg::execute(const EventContext&) const {
   std::cout << "HALLO WELT!" << std::endl;
   return StatusCode::SUCCESS;
 }

--- a/k4ActsTracking/src/components/EmptyAlg.h
+++ b/k4ActsTracking/src/components/EmptyAlg.h
@@ -19,10 +19,10 @@
 #pragma once
 
 // GAUDI
+#include "Gaudi/Algorithm.h"
 #include "Gaudi/Property.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
 
-class EmptyAlg : public GaudiAlgorithm {
+class EmptyAlg : public Gaudi::Algorithm {
 public:
   explicit EmptyAlg(const std::string&, ISvcLocator*);
   virtual ~EmptyAlg();
@@ -33,7 +33,7 @@ public:
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  virtual StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */


### PR DESCRIPTION
This PR removes the dependency on GaudiAlg. Pretty trivial PR, really.
- Changed CMakeLists to remove `LINK Gaudi::GaudiAlgLib`
- Changed headers from `GaudiAlg/GaudiAlgorithm.hpp` to `Gaudi/Algorithm.hpp`
- Changed base class from `GaudiAlgorithm` to `Gaudi::Algorithm`
- Changed execute signature to `execute(const EventContext&) const`

Builds against gaudi@39.2
```
==> Installing k4actstracking-main-fytvnix6vleg7d7efkv5ma2de2xtip7r [263/263]
==> No binary for k4actstracking-main-fytvnix6vleg7d7efkv5ma2de2xtip7r found: installing from source
==> Already patched k4actstracking
==> k4actstracking: Executing phase: 'cmake'
==> k4actstracking: Executing phase: 'build'
==> k4actstracking: Executing phase: 'install'
==> Warning: Module file /home/wdconinc/git/spack/share/spack/lmod/linux-ubuntu25.04-x86_64/openmpi/5.0.7-ng644zp/gcc/14.2.0/k4actstracking/main-fytvnix.lua exists and will not be overwritten
==> k4actstracking: Successfully installed k4actstracking-main-fytvnix6vleg7d7efkv5ma2de2xtip7r
  Stage: 0.00s.  Cmake: 0.00s.  Build: 0.07s.  Install: 0.07s.  Post-install: 0.15s.  Total: 0.97s
[+] /opt/software/linux-ubuntu25.04-skylake/gcc-14.2.0/k4actstracking-main-fytvnix6vleg7d7efkv5ma2de2xtip7r
```

BEGINRELEASENOTES
- Remove dependence on GaudiAlg

ENDRELEASENOTES