### PR TITLE
Use the correct env variable for fetching ODD

### DIFF
--- a/test/options/geosvc.py
+++ b/test/options/geosvc.py
@@ -24,7 +24,9 @@ from Configurables import ActsGeoSvc, ApplicationMgr, GeoSvc
 algList = []
 
 dd4hep_geo = GeoSvc("GeoSvc")
-dd4hep_geo.detectors = [f"{os.environ['OPENDATADETECTOR']}/xml/OpenDataDetector.xml"]
+dd4hep_geo.detectors = [
+    f"{os.environ['OPENDATADETECTOR_DATA']}/xml/OpenDataDetector.xml"
+]
 dd4hep_geo.EnableGeant4Geo = False
 
 acts_geo = ActsGeoSvc("ActsGeoSvc")


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `OPENDATADETECTOR_DATA` to get to the ODD geometry file since `OPENDATADETECTOR` has been removed.

ENDRELEASENOTES

See https://github.com/key4hep/key4hep-spack/issues/652
