### PR TITLE
fix: add LANGUAGES CXX to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ limitations under the License.
 ]]
 CMAKE_MINIMUM_REQUIRED(VERSION 3.18)
 
-project(k4ActsTracking)
+project(k4ActsTracking LANGUAGES CXX)
 
 find_package(ROOT COMPONENTS RIO Tree)
 find_package(EDM4HEP)


### PR DESCRIPTION
This project only uses C++, so the default C and CXX languages in CMake are unnecessary.

BEGINRELEASENOTES
- Add LANGUAGES CXX to CMakeLists.txt

ENDRELEASENOTES
