### PR TITLE
Switch to new ACTS CMake target names

### DIFF
--- a/k4ActsTracking/CMakeLists.txt
+++ b/k4ActsTracking/CMakeLists.txt
@@ -34,7 +34,7 @@ gaudi_add_module(k4ActsTrackingPlugins
   k4FWCore::k4FWCore
   EDM4HEP::edm4hep
   DD4hep::DDCore DD4hep::DDRec
-  ActsCore ActsPluginDD4hep
+  Acts::Core Acts::PluginDD4hep
   )
 target_include_directories(k4ActsTrackingPlugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to new ACTS CMake target names

ENDRELEASENOTES

This was necessary for me locally to properly have the include directories of `Acts::Core`. I am not sure if we want to have some version guards around this or whether these have been around long enough to "just work".