### PR TITLE
Add a CI workflow based on a muon collider SW stack image

### DIFF
--- a/.github/workflows/mucoll-ci.yml
+++ b/.github/workflows/mucoll-ci.yml
@@ -25,5 +25,6 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "
           cmake --build build
-          ctest --test-dir build -j$(nproc)
+          # Tests need OpenDataDetector, which is not present in the mucoll image atm
+          # ctest --test-dir build -j$(nproc) --output-on-failure
           cmake --build build --target install

--- a/.github/workflows/mucoll-ci.yml
+++ b/.github/workflows/mucoll-ci.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build and test
         run: |
-          setup_mucoll
+          mucoll_setup_script=$(grep setup_mucoll /etc/profile.d/aliases.sh | awk -F '=' '{print $2}')
+          source ${mucoll_setup_script:2:-1}
           cmake -B build -S . -GNinja \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/install \

--- a/.github/workflows/mucoll-ci.yml
+++ b/.github/workflows/mucoll-ci.yml
@@ -1,0 +1,28 @@
+name: MuColl Image Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-mucoll-image:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/muoncollidersoft/mucoll-sim-ubuntu24:full_gaudi_test
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build and test
+        run: |
+          setup_mucoll
+          cmake -B build -S . -GNinja \
+            -DCMAKE_CXX_STANDARD=20 \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "
+          cmake --build build
+          ctest --test-dir build -j$(nproc)
+          cmake --build build --target install

--- a/.github/workflows/mucoll-ci.yml
+++ b/.github/workflows/mucoll-ci.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build and test
         run: |
-          mucoll_setup_script=$(grep setup_mucoll /etc/profile.d/aliases.sh | awk -F '=' '{print $2}')
-          source ${mucoll_setup_script:2:-1}
+          # setup_mucoll alias is not available, so we go for the setup script path directly
+          . /opt/spack/opt/spack/*/*/*/*/*/mucoll-stack-20*/setup.sh
           cmake -B build -S . -GNinja \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/install \


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a CI workflow based on a MuonCollider SW stack image to ease the integration of muon colider developments

ENDRELEASENOTES

The main difference wrt the Key4hep stack is that the muon collider stack is still based on acts@32. By having CI that runs there we can better judge whether we can make a somewhat transparent migration or whether we will have to make a breaking change and jump at some point.

Since the mucoll stack doesn't come with the OpenDataDetector, the tests are disabled for now.

@madbaron FYI
