### PR TITLE
Cleanup acts geo svc

### DIFF
--- a/k4ActsTracking/CMakeLists.txt
+++ b/k4ActsTracking/CMakeLists.txt
@@ -48,6 +48,7 @@ gaudi_add_module(k4ActsTrackingPlugins
   k4FWCore::k4FWCore
   EDM4HEP::edm4hep
   DD4hep::DDCore DD4hep::DDRec
+  k4ActsTracking
   ${ACTS_PLUGIN_TARGETS}
 )
 target_include_directories(k4ActsTrackingPlugins PUBLIC

--- a/k4ActsTracking/src/components/ActsGeoSvc.cpp
+++ b/k4ActsTracking/src/components/ActsGeoSvc.cpp
@@ -36,7 +36,7 @@ using namespace Gaudi;
 
 DECLARE_COMPONENT(ActsGeoSvc)
 
-ActsGeoSvc::ActsGeoSvc(const std::string& name, ISvcLocator* svc) : base_class(name, svc), m_log(msgSvc(), name) {}
+ActsGeoSvc::ActsGeoSvc(const std::string& name, ISvcLocator* svc) : base_class(name, svc) {}
 
 StatusCode ActsGeoSvc::initialize() {
   m_dd4hepGeo = svcLocator()->service<IGeoSvc>(m_geoSvcName)->getDetector();
@@ -64,19 +64,17 @@ StatusCode ActsGeoSvc::initialize() {
 
   /// Setting geometry debug option
   if (m_debugGeometry == true) {
-    m_log << MSG::INFO << "Geometry debugging is ON." << endmsg;
+    info() << "Geometry debugging is ON." << endmsg;
 
     if (createGeoObj().isFailure()) {
-      m_log << MSG::ERROR << "Could not create geometry OBJ" << endmsg;
+      error() << "Could not create geometry OBJ" << endmsg;
       return StatusCode::FAILURE;
     } else {
-      m_log << MSG::INFO << "Geometry OBJ SUCCESSFULLY created" << endmsg;
+      info() << "Geometry OBJ SUCCESSFULLY created" << endmsg;
     }
   } else {
-    m_log << MSG::VERBOSE << "Geometry debugging is OFF." << endmsg;
-    return StatusCode::SUCCESS;
+    info() << "Geometry converted without checking if GeoObj can be created" << endmsg;
   }
-  std::cout << "works!" << std::endl;
 
   return StatusCode::SUCCESS;
 }
@@ -102,7 +100,7 @@ StatusCode ActsGeoSvc::createGeoObj() {
     Acts::GeometryView3D::drawSurface(m_obj, *surface, m_trackingGeoCtx);
   });
   m_obj.write(m_outputFileName.value());
-  m_log << MSG::INFO << m_outputFileName << " SUCCESSFULLY written." << endmsg;
+  info() << m_outputFileName << " SUCCESSFULLY written." << endmsg;
 
   return StatusCode::SUCCESS;
 }

--- a/k4ActsTracking/src/components/ActsGeoSvc.cpp
+++ b/k4ActsTracking/src/components/ActsGeoSvc.cpp
@@ -45,8 +45,6 @@ DECLARE_COMPONENT(ActsGeoSvc)
 
 ActsGeoSvc::ActsGeoSvc(const std::string& name, ISvcLocator* svc) : base_class(name, svc), m_log(msgSvc(), name) {}
 
-ActsGeoSvc::~ActsGeoSvc(){};
-
 StatusCode ActsGeoSvc::initialize() {
   m_dd4hepGeo = svcLocator()->service<IGeoSvc>(m_geoSvcName)->getDetector();
   // necessary?

--- a/k4ActsTracking/src/components/ActsGeoSvc.cpp
+++ b/k4ActsTracking/src/components/ActsGeoSvc.cpp
@@ -28,8 +28,12 @@
 #if __has_include("ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp")
 #include "ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp"
 #else
-#define ACTS_OLD_PLUGINS 1
 #include "Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp"
+namespace ActsPlugins {
+  using Acts::convertDD4hepDetector;
+  using Acts::sortDetElementsByID;
+
+}  // namespace ActsPlugins
 #endif
 
 using namespace Gaudi;
@@ -50,17 +54,10 @@ StatusCode ActsGeoSvc::initialize() {
   double            layerEnvelopeZ        = Acts::UnitConstants::mm;
   double            defaultLayerThickness = Acts::UnitConstants::fm;
 
-#ifdef ACTS_OLD_PLUGINS
-  using Acts::convertDD4hepDetector;
-  using Acts::sortDetElementsByID;
-#else
-  using ActsPlugins::convertDD4hepDetector;
-  using ActsPlugins::sortDetElementsByID;
-#endif
-  auto logger = makeActsGaudiLogger(this);
-  m_trackingGeo =
-      convertDD4hepDetector(m_dd4hepGeo->world(), *logger, bTypePhi, bTypeR, bTypeZ, layerEnvelopeR, layerEnvelopeZ,
-                            defaultLayerThickness, sortDetElementsByID, m_trackingGeoCtx, m_materialDeco);
+  auto logger   = makeActsGaudiLogger(this);
+  m_trackingGeo = ActsPlugins::convertDD4hepDetector(
+      m_dd4hepGeo->world(), *logger, bTypePhi, bTypeR, bTypeZ, layerEnvelopeR, layerEnvelopeZ, defaultLayerThickness,
+      ActsPlugins::sortDetElementsByID, m_trackingGeoCtx, m_materialDeco);
 
   /// Setting geometry debug option
   if (m_debugGeometry == true) {

--- a/k4ActsTracking/src/components/ActsGeoSvc.cpp
+++ b/k4ActsTracking/src/components/ActsGeoSvc.cpp
@@ -18,6 +18,8 @@
  */
 #include "ActsGeoSvc.h"
 
+#include "k4ActsTracking/ActsGaudiLogger.h"
+
 #include "k4Interface/IGeoSvc.h"
 
 #include "Acts/Geometry/TrackingGeometry.hpp"
@@ -55,7 +57,7 @@ StatusCode ActsGeoSvc::initialize() {
   using ActsPlugins::convertDD4hepDetector;
   using ActsPlugins::sortDetElementsByID;
 #endif
-  auto logger = Acts::getDefaultLogger("k4ActsTracking", m_actsLoggingLevel);
+  auto logger = makeActsGaudiLogger(this);
   m_trackingGeo =
       convertDD4hepDetector(m_dd4hepGeo->world(), *logger, bTypePhi, bTypeR, bTypeZ, layerEnvelopeR, layerEnvelopeZ,
                             defaultLayerThickness, sortDetElementsByID, m_trackingGeoCtx, m_materialDeco);

--- a/k4ActsTracking/src/components/ActsGeoSvc.cpp
+++ b/k4ActsTracking/src/components/ActsGeoSvc.cpp
@@ -21,9 +21,6 @@
 #include "k4Interface/IGeoSvc.h"
 
 #include "Acts/Geometry/TrackingGeometry.hpp"
-#include "Acts/MagneticField/MagneticFieldContext.hpp"
-#include "Acts/Surfaces/PlaneSurface.hpp"
-#include "Acts/Utilities/Logger.hpp"
 #include "Acts/Visualization/GeometryView3D.hpp"
 #include "Acts/Visualization/ObjVisualization3D.hpp"
 #if __has_include("ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp")
@@ -32,12 +29,6 @@
 #define ACTS_OLD_PLUGINS 1
 #include "Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp"
 #endif
-
-#include "DD4hep/Printout.h"
-
-#include "GaudiKernel/Service.h"
-
-#include "TGeoManager.h"
 
 using namespace Gaudi;
 

--- a/k4ActsTracking/src/components/ActsGeoSvc.h
+++ b/k4ActsTracking/src/components/ActsGeoSvc.h
@@ -71,9 +71,6 @@ private:
   /// Output file name
   Gaudi::Property<std::string> m_outputFileName{this, "outputFileName", "", "Output file name"};
 
-  /// Gaudi logging output
-  MsgStream m_log;
-
 public:
   ActsGeoSvc(const std::string& name, ISvcLocator* svc);
 

--- a/k4ActsTracking/src/components/ActsGeoSvc.h
+++ b/k4ActsTracking/src/components/ActsGeoSvc.h
@@ -77,7 +77,7 @@ private:
 public:
   ActsGeoSvc(const std::string& name, ISvcLocator* svc);
 
-  virtual ~ActsGeoSvc();
+  virtual ~ActsGeoSvc() = default;
 
   virtual StatusCode initialize() final;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Cleanup `ActsGeoSvc`
  - Remove unused includes
  - Use Gaudi integrated Acts logging introduced in #27 
  - Cleanup logging by using logging facilities directly

ENDRELEASENOTES
