### PR TITLE
Make error messages more useful and do some cleanup

### DIFF
--- a/k4ActsTracking/include/k4ActsTracking/ACTSSeededCKFTrackingAlg.hxx
+++ b/k4ActsTracking/include/k4ActsTracking/ACTSSeededCKFTrackingAlg.hxx
@@ -254,7 +254,7 @@ std::vector<Acts::BoundTrackParameters> ACTSSeededCKFTrackingAlg::findSeeds(
     const Acts::Vector3         seedPos(bottomSP->x(), bottomSP->y(), bottomSP->z());
     Acts::Result<Acts::Vector3> seedField = magneticField()->getField(seedPos, magCache);
     if (!seedField.ok()) {
-      throw std::runtime_error("Field lookup error: " + std::to_string(seedField.error().value()));
+      throw std::runtime_error("Field lookup error: " + seedField.error().message());
     }
 
     Acts::Result<Acts::BoundVector> optParams =
@@ -286,7 +286,7 @@ std::vector<Acts::BoundTrackParameters> ACTSSeededCKFTrackingAlg::findSeeds(
 
     Acts::Result<Acts::Vector3> hitField = magneticField()->getField(globalPos, magCache);
     if (!hitField.ok()) {
-      throw std::runtime_error("Field lookup error: " + std::to_string(hitField.error().value()));
+      throw std::runtime_error("Field lookup error: " + hitField.error().message());
     }
 
     auto seedTrackState = ACTSTracking::ACTS2edm4hep_trackState(edm4hep::TrackState::AtFirstHit, paramseed,

--- a/k4ActsTracking/include/k4ActsTracking/Helpers.hxx
+++ b/k4ActsTracking/include/k4ActsTracking/Helpers.hxx
@@ -80,9 +80,9 @@ namespace ACTSTracking {
  *
  * \return Track with equivalent parameters of the ACTS track
  */
-  edm4hep::MutableTrack ACTS2edm4hep_track(const TrackResult&                           fitter_res,
-                                           std::shared_ptr<Acts::MagneticFieldProvider> magneticField,
-                                           Acts::MagneticFieldProvider::Cache&          magCache);
+  edm4hep::MutableTrack ACTS2edm4hep_track(const TrackResult&                                 fitter_res,
+                                           std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
+                                           Acts::MagneticFieldProvider::Cache&                magCache);
 
   //! Convert ACTS track state class to edm4hep class
   /**

--- a/k4ActsTracking/src/components/ACTSSeededCKFTrackingAlg.cxx
+++ b/k4ActsTracking/src/components/ACTSSeededCKFTrackingAlg.cxx
@@ -28,10 +28,6 @@
 #include <edm4hep/TrackState.h>
 #include <edm4hep/TrackerHitPlane.h>
 
-// Gaudi
-#include <GaudiKernel/ITHistSvc.h>
-#include <GaudiKernel/MsgStream.h>
-
 // ACTS
 #include <Acts/Seeding/SpacePointGrid.hpp>
 #include <Acts/Surfaces/PerigeeSurface.hpp>
@@ -60,10 +56,6 @@ ACTSSeededCKFTrackingAlg::ACTSSeededCKFTrackingAlg(const std::string& name, ISvc
 StatusCode ACTSSeededCKFTrackingAlg::initialize() {
   // Initialize the base
   StatusCode init = ACTSAlgBase::initialize();
-
-  // Initialize timing histograms
-  SmartIF<ITHistSvc> histSvc;
-  histSvc = serviceLocator()->service("THistSvc");
 
   // Initialize seeding layers
   std::vector<std::string> seedingLayers;

--- a/k4ActsTracking/src/components/Helpers.cxx
+++ b/k4ActsTracking/src/components/Helpers.cxx
@@ -63,9 +63,9 @@ namespace ACTSTracking {
     return inpath;
   }
 
-  edm4hep::MutableTrack ACTS2edm4hep_track(const TrackResult&                           fitter_res,
-                                           std::shared_ptr<Acts::MagneticFieldProvider> magneticField,
-                                           Acts::MagneticFieldProvider::Cache&          magCache) {
+  edm4hep::MutableTrack ACTS2edm4hep_track(const TrackResult&                                 fitter_res,
+                                           std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
+                                           Acts::MagneticFieldProvider::Cache&                magCache) {
     // Create new object
     edm4hep::MutableTrack track{};
 

--- a/k4ActsTracking/src/components/Helpers.cxx
+++ b/k4ActsTracking/src/components/Helpers.cxx
@@ -78,7 +78,7 @@ namespace ACTSTracking {
     const Acts::Vector3         zeroPos(0, 0, 0);
     Acts::Result<Acts::Vector3> fieldRes = magneticField->getField(zeroPos, magCache);
     if (!fieldRes.ok()) {
-      throw std::runtime_error("Field lookup error: " + fieldRes.error().value());
+      throw std::runtime_error("Field lookup error: " + fieldRes.error().message());
     }
     Acts::Vector3 field = *fieldRes;
 
@@ -107,7 +107,7 @@ namespace ACTSTracking {
 
       fieldRes = magneticField->getField(hitPos, magCache);
       if (!fieldRes.ok()) {
-        throw std::runtime_error("Field lookup error: " + fieldRes.error().value());
+        throw std::runtime_error("Field lookup error: " + fieldRes.error().message());
       }
       field = *fieldRes;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Make error messages from ACTS (propagated by us via exceptions) more useful by including the error message instead of just the numerical error code
- Remove a few unused services an includes from the `ACTSSeededCKFTrackingAlg`
- Make helper functions accept a `const` magnetic field because it can

ENDRELEASENOTES
