### PR TITLE
Do not fail mucoll CI due to deprecation warnings

### DIFF
--- a/.github/workflows/mucoll-ci.yml
+++ b/.github/workflows/mucoll-ci.yml
@@ -57,7 +57,7 @@ jobs:
           cmake -B build -S . -GNinja \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations"
           cmake --build build
           # Tests need OpenDataDetector, which is not present in the mucoll image atm
           # ctest --test-dir build -j$(nproc) --output-on-failure


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not fail the mucoll based CI just because of deprecation warnings

ENDRELEASENOTES
