### PR TITLE
Link to k4FWCore::k4Interface, used in a few files in the plugins

### DIFF
--- a/k4ActsTracking/CMakeLists.txt
+++ b/k4ActsTracking/CMakeLists.txt
@@ -54,6 +54,7 @@ gaudi_add_module(k4ActsTrackingPlugins
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore
+  k4FWCore::k4Interface
   DD4hep::DDCore DD4hep::DDRec
   k4ActsTracking
   Acts::Core


### PR DESCRIPTION
This works fine in CI but for me it doesn't. It's used in a few files:

```
k4ActsTracking/include/k4ActsTracking/ACTSAlgBase.hxx
43:#include <k4Interface/IGeoSvc.h>

k4ActsTracking/src/components/ActsGeoSvc.h
24:#include <k4Interface/IGeoSvc.h>

k4ActsTracking/src/components/ActsTestPropagator.cpp
24:#include <k4Interface/IGeoSvc.h>
```
so to be correct it should be there.


BEGINRELEASENOTES
- Link to k4FWCore::k4Interface, used in a few files in the plugins

ENDRELEASENOTES