### PR TITLE
Replace removed Acts TrackParameters.hpp with specific headers

### DIFF
--- a/k4ActsTracking/include/k4ActsTracking/ACTSSeededCKFTrackingAlg.hxx
+++ b/k4ActsTracking/include/k4ActsTracking/ACTSSeededCKFTrackingAlg.hxx
@@ -31,7 +31,9 @@
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/SpacePointContainer.hpp>
 #include <Acts/EventData/TrackContainer.hpp>
-#include <Acts/EventData/TrackParameters.hpp>
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#include <Acts/EventData/FreeTrackParameters.hpp>
+#include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>

--- a/k4ActsTracking/include/k4ActsTracking/ACTSSeededCKFTrackingAlg.hxx
+++ b/k4ActsTracking/include/k4ActsTracking/ACTSSeededCKFTrackingAlg.hxx
@@ -29,11 +29,11 @@
 
 // ACTS
 #include <Acts/Definitions/Units.hpp>
-#include <Acts/EventData/SpacePointContainer.hpp>
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/BoundTrackParameters.hpp>
 #include <Acts/EventData/FreeTrackParameters.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
+#include <Acts/EventData/SpacePointContainer.hpp>
+#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>

--- a/k4ActsTracking/include/k4ActsTracking/CKFTrackingAlg.hxx
+++ b/k4ActsTracking/include/k4ActsTracking/CKFTrackingAlg.hxx
@@ -19,7 +19,9 @@
 #pragma once
 
 // ACTS
-#include <Acts/EventData/TrackParameters.hpp>
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#include <Acts/EventData/FreeTrackParameters.hpp>
+#include <Acts/EventData/ParticleHypothesis.hpp>
 
 // Standard
 #include <cmath>

--- a/k4ActsTracking/include/k4ActsTracking/Helpers.hxx
+++ b/k4ActsTracking/include/k4ActsTracking/Helpers.hxx
@@ -35,13 +35,14 @@
 #include <GaudiKernel/StatusCode.h>
 
 // ACTS
-#include <Acts/EventData/TrackParameters.hpp>
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#include <Acts/EventData/FreeTrackParameters.hpp>
+#include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/TrackFinding/CombinatorialKalmanFilter.hpp>
 #include <Acts/TrackFitting/KalmanFitter.hpp>
-#include "Acts/EventData/ParticleHypothesis.hpp"
 
 // ACTSTracking
 #include "k4ActsTracking/SourceLink.hxx"

--- a/k4ActsTracking/src/components/ActsTestPropagator.cpp
+++ b/k4ActsTracking/src/components/ActsTestPropagator.cpp
@@ -25,9 +25,10 @@
 
 #include <podio/UserDataCollection.h>
 
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#include <Acts/EventData/FreeTrackParameters.hpp>
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
-#include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/MagneticField/ConstantBField.hpp>
 #include <Acts/MagneticField/MagneticFieldContext.hpp>

--- a/k4ActsTracking/src/components/ActsTestPropagator.cpp
+++ b/k4ActsTracking/src/components/ActsTestPropagator.cpp
@@ -27,7 +27,6 @@
 
 #include <Acts/EventData/BoundTrackParameters.hpp>
 #include <Acts/EventData/FreeTrackParameters.hpp>
-#include <Acts/EventData/GenericBoundTrackParameters.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/MagneticField/ConstantBField.hpp>

--- a/k4ActsTracking/src/components/CKFTrackingAlg.cpp
+++ b/k4ActsTracking/src/components/CKFTrackingAlg.cpp
@@ -47,11 +47,11 @@
 
 // ACTS
 #include <Acts/Definitions/Units.hpp>
-#include <Acts/EventData/SpacePointContainer.hpp>
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/BoundTrackParameters.hpp>
 #include <Acts/EventData/FreeTrackParameters.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
+#include <Acts/EventData/SpacePointContainer.hpp>
+#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>

--- a/k4ActsTracking/src/components/CKFTrackingAlg.cpp
+++ b/k4ActsTracking/src/components/CKFTrackingAlg.cpp
@@ -49,7 +49,9 @@
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/SpacePointContainer.hpp>
 #include <Acts/EventData/TrackContainer.hpp>
-#include <Acts/EventData/TrackParameters.hpp>
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#include <Acts/EventData/FreeTrackParameters.hpp>
+#include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>


### PR DESCRIPTION
Upstream Acts removed the deprecated forwarding header Acts/EventData/TrackParameters.hpp, which broke compilation. Replace it with the specific headers it used to forward (BoundTrackParameters.hpp, FreeTrackParameters.hpp, ParticleHypothesis.hpp).


BEGINRELEASENOTES
- Updating the headers not to use deprecated APIs (https://github.com/acts-project/acts/commit/0045fb428dee8bf1246c5152a5e49972d3e25232)

ENDRELEASENOTES
