### PR TITLE
Fix gcc15 warnings

### DIFF
--- a/k4ActsTracking/include/k4ActsTracking/Measurement.hxx
+++ b/k4ActsTracking/include/k4ActsTracking/Measurement.hxx
@@ -111,7 +111,10 @@ namespace ACTSTracking {
     template <std::size_t dim> Acts::SubspaceIndices<dim> subspaceIndices() const {
       assert(dim == size());
       Acts::SubspaceIndices<dim> result;
-      std::copy(m_subspaceIndices.begin(), m_subspaceIndices.end(), result.begin());
+      // Copy exactly dim elements (== size(), see assert above) so the compiler can
+      // prove the destination bound; copying the full runtime-sized range trips
+      // -Werror=array-bounds on GCC 15.
+      std::copy_n(m_subspaceIndices.begin(), dim, result.begin());
       return result;
     }
 

--- a/k4ActsTracking/src/components/GeometryIdMappingTool.cxx
+++ b/k4ActsTracking/src/components/GeometryIdMappingTool.cxx
@@ -238,7 +238,7 @@ Acts::GeometryIdentifier GeometryIdMappingTool::getGeometryID(uint32_t systemID,
   switch (signSystemID) {
     case VertexBarrel:
       if (det_type == GeometryIdMappingTool::DetSchema::MAIA_v0) {
-        uint32_t my_layer_ID;
+        uint32_t my_layer_ID = 0;
         switch (layerID) {
           case 0:
             my_layer_ID = 0;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed gcc15 warnings (treated as failures) in ubuntu26 CI build tests

ENDRELEASENOTES
